### PR TITLE
Adding methods to register additional SqlAdapters.

### DIFF
--- a/Dapper.Database/Extensions/SqlMapperExtensions.cs
+++ b/Dapper.Database/Extensions/SqlMapperExtensions.cs
@@ -56,8 +56,8 @@ namespace Dapper.Database.Extensions
         private static readonly ConcurrentDictionary<RuntimeTypeHandle, TableInfo> TableInfos = new ConcurrentDictionary<RuntimeTypeHandle, TableInfo>();
 
         private static readonly ISqlAdapter DefaultAdapter = new SqlServerAdapter();
-        private static readonly Dictionary<string, ISqlAdapter> AdapterDictionary
-            = new Dictionary<string, ISqlAdapter>
+        private static readonly ConcurrentDictionary<string, ISqlAdapter> AdapterDictionary
+            = new ConcurrentDictionary<string, ISqlAdapter>
             {
                 ["sqlconnection"] = new SqlServerAdapter(),
                 ["sqlceconnection"] = new SqlCeServerAdapter(),
@@ -99,15 +99,58 @@ namespace Dapper.Database.Extensions
         /// </summary>
         public static GetDatabaseTypeDelegate GetDatabaseType;
 
+        private static string CleanSqlAdapterName(string name) => name.ToLowerInvariant();
+
+        private static string GetSqlAdapterName<TConnection>() where TConnection : IDbConnection, new()
+            => CleanSqlAdapterName(GetDatabaseType?.Invoke(new TConnection()) ?? typeof(TConnection).Name);
+
+        private static string GetSqlAdapterName(IDbConnection connection)
+        {
+            if (connection == null) throw new ArgumentNullException(nameof(connection));
+
+            return CleanSqlAdapterName(GetDatabaseType?.Invoke(connection) ?? connection.GetType().Name);
+        }
+
         private static ISqlAdapter GetFormatter(IDbConnection connection)
         {
-            var name = GetDatabaseType?.Invoke(connection).ToLower()
-                       ?? connection.GetType().Name.ToLower();
+            var name = GetSqlAdapterName(connection);
 
             return !AdapterDictionary.ContainsKey(name)
                 ? DefaultAdapter
                 : AdapterDictionary[name];
         }
+
+        /// <summary>
+        /// Configure the specified name to resolve to a custom SQL adapter.
+        /// </summary>
+        /// <param name="name">The name to assign the adapter.</param>
+        /// <param name="adapter">An <see cref="ISqlAdapter"/> to register under <paramref name="name" />.</param>
+        /// <exception cref="NullReferenceException">if <paramref name="name"/> or <paramref name="adapter"/> is null.</exception>
+        public static void AddSqlAdapter(string name, ISqlAdapter adapter)
+        {
+            if (name == null) throw new ArgumentNullException(nameof(name));
+            if (adapter == null) throw new ArgumentNullException(nameof(adapter));
+
+            AdapterDictionary.AddOrUpdate(CleanSqlAdapterName(name), adapter, (_name, oldAdapter) => adapter);
+        }
+
+        /// <summary>
+        /// Configure the specified connection to resolve to a custom SQL adapter.
+        /// </summary>
+        /// <param name="connection">An <see cref="IDbConnection"/> for which the concrete type will be mapped to the specified adapter by name.</param>
+        /// <param name="adapter">An <see cref="ISqlAdapter"/> to register under <paramref name="connection" />.</param>
+        /// <exception cref="NullReferenceException">if <paramref name="connection"/> or <paramref name="adapter"/> is null.</exception>
+        public static void AddSqlAdapter(IDbConnection connection, ISqlAdapter adapter)
+            => AddSqlAdapter(GetSqlAdapterName(connection), adapter);
+
+        /// <summary>
+        /// Configure the specified connection to resolve to a custom SQL adapter.
+        /// </summary>
+        /// <typeparam name="TConnection">An <see cref="IDbConnection"/> type which will be mapped to the specified adapter by its <see cref="System.Reflection.MemberInfo.Name"/>.</typeparam>
+        /// <param name="adapter">An <see cref="ISqlAdapter"/> to register under <typeparamref name="TConnection" />.</param>
+        /// <exception cref="NullReferenceException">if <paramref name="adapter"/> is null.</exception>
+        public static void AddSqlAdapter<TConnection>(ISqlAdapter adapter) where TConnection : IDbConnection, new()
+            => AddSqlAdapter(GetSqlAdapterName<TConnection>(), adapter);
 
     }
 }


### PR DESCRIPTION
I have added some methods to `SqlMapperExensions` that allow registration of new or replacement `ISqlAdapter` instances.  This will allow for adding third-party `ISqlAdapter` implementations as well as replacing existing mappings if desired.

I originally was going to use the `SqlMapperExtensions.GetDatabaseType` hook to accomplish this, but this only lets you remap the name of an existing adapter, not add a new one.

The reason I need to add a new adapter is that I have been working on a way to use Dapper CRUD operations with Oracle, but Oracle makes this very difficult due to its driver not supporting a lot of nice features that most other third-party drivers, such as bind variable syntax transformation and certain data types (most notably `DbType.Guid`), and the only solutions I have been able to come up with would not work in a general-purpose project.  Hence, I need to be able to add a custom adapter and not just provide a built-in one.

Please do not hesitate to let me know if you have any questions or concerns about this PR.

Thanks!

\# Chris