### PR TITLE
Fixing time and aliases.

### DIFF
--- a/Dapper.Database/Adapters/MySqlAdapter.cs
+++ b/Dapper.Database/Adapters/MySqlAdapter.cs
@@ -29,7 +29,7 @@ namespace Dapper.Database.Adapters
             if ( tableInfo.GeneratedColumns.Any() && tableInfo.KeyColumns.Any() )
             {
 
-                var selectcmd = new StringBuilder($"select {EscapeColumnList(tableInfo.GeneratedColumns, tableInfo.TableName)} from {EscapeTableName(tableInfo)} ");
+                var selectcmd = new StringBuilder($"select {EscapeColumnListWithAliases(tableInfo.GeneratedColumns, tableInfo.TableName)} from {EscapeTableName(tableInfo)} ");
 
                 if ( tableInfo.KeyColumns.Any(k => k.IsIdentity) )
                 {
@@ -86,7 +86,7 @@ namespace Dapper.Database.Adapters
 
             if ( tableInfo.GeneratedColumns.Any() && tableInfo.KeyColumns.Any() )
             {
-                var selectcmd = new StringBuilder($"select {EscapeColumnList(tableInfo.GeneratedColumns, tableInfo.TableName)} from {EscapeTableName(tableInfo)} ");
+                var selectcmd = new StringBuilder($"select {EscapeColumnListWithAliases(tableInfo.GeneratedColumns, tableInfo.TableName)} from {EscapeTableName(tableInfo)} ");
                 selectcmd.Append($"where {EscapeWhereList(tableInfo.KeyColumns)};");
 
                 connection.Execute(cmd.ToString(), entityToUpdate, transaction, commandTimeout);
@@ -129,7 +129,7 @@ namespace Dapper.Database.Adapters
             if ( tableInfo.GeneratedColumns.Any() && tableInfo.KeyColumns.Any() )
             {
 
-                var selectcmd = new StringBuilder($"select {EscapeColumnList(tableInfo.GeneratedColumns, tableInfo.TableName)} from {EscapeTableName(tableInfo)} ");
+                var selectcmd = new StringBuilder($"select {EscapeColumnListWithAliases(tableInfo.GeneratedColumns, tableInfo.TableName)} from {EscapeTableName(tableInfo)} ");
 
                 if ( tableInfo.KeyColumns.Any(k => k.IsIdentity) )
                 {
@@ -186,7 +186,7 @@ namespace Dapper.Database.Adapters
 
             if ( tableInfo.GeneratedColumns.Any() && tableInfo.KeyColumns.Any() )
             {
-                var selectcmd = new StringBuilder($"select {EscapeColumnList(tableInfo.GeneratedColumns, tableInfo.TableName)} from {EscapeTableName(tableInfo)} ");
+                var selectcmd = new StringBuilder($"select {EscapeColumnListWithAliases(tableInfo.GeneratedColumns, tableInfo.TableName)} from {EscapeTableName(tableInfo)} ");
                 selectcmd.Append($"where {EscapeWhereList(tableInfo.KeyColumns)};");
 
                 await connection.ExecuteAsync(cmd.ToString(), entityToUpdate, transaction, commandTimeout);

--- a/Dapper.Database/Adapters/SQLiteAdapter.cs
+++ b/Dapper.Database/Adapters/SQLiteAdapter.cs
@@ -27,7 +27,7 @@ namespace Dapper.Database.Adapters
 
             if (tableInfo.GeneratedColumns.Any() && tableInfo.KeyColumns.Any())
             {
-                cmd.Append($"; select {EscapeColumnList(tableInfo.GeneratedColumns, tableInfo.TableName)} from {EscapeTableName(tableInfo)} ");
+                cmd.Append($"; select {EscapeColumnListWithAliases(tableInfo.GeneratedColumns, tableInfo.TableName)} from {EscapeTableName(tableInfo)} ");
 
                 if (tableInfo.KeyColumns.Any(k => k.IsIdentity))
                 {
@@ -78,7 +78,7 @@ namespace Dapper.Database.Adapters
 
             if (tableInfo.GeneratedColumns.Any() && tableInfo.KeyColumns.Any())
             {
-                cmd.Append($"; select {EscapeColumnList(tableInfo.GeneratedColumns, tableInfo.TableName)} from {EscapeTableName(tableInfo)} ");
+                cmd.Append($"; select {EscapeColumnListWithAliases(tableInfo.GeneratedColumns, tableInfo.TableName)} from {EscapeTableName(tableInfo)} ");
                 cmd.Append($"where {EscapeWhereList(tableInfo.KeyColumns)};");
 
                 var multi = connection.QueryMultiple(cmd.ToString(), entityToUpdate, transaction, commandTimeout);
@@ -119,7 +119,7 @@ namespace Dapper.Database.Adapters
 
             if (tableInfo.GeneratedColumns.Any() && tableInfo.KeyColumns.Any())
             {
-                cmd.Append($"; select {EscapeColumnList(tableInfo.GeneratedColumns, tableInfo.TableName)} from {EscapeTableName(tableInfo)} ");
+                cmd.Append($"; select {EscapeColumnListWithAliases(tableInfo.GeneratedColumns, tableInfo.TableName)} from {EscapeTableName(tableInfo)} ");
 
                 if (tableInfo.KeyColumns.Any(k => k.IsIdentity))
                 {
@@ -170,7 +170,7 @@ namespace Dapper.Database.Adapters
 
             if (tableInfo.GeneratedColumns.Any() && tableInfo.KeyColumns.Any())
             {
-                cmd.Append($"; select {EscapeColumnList(tableInfo.GeneratedColumns, tableInfo.TableName)} from {EscapeTableName(tableInfo)} ");
+                cmd.Append($"; select {EscapeColumnListWithAliases(tableInfo.GeneratedColumns, tableInfo.TableName)} from {EscapeTableName(tableInfo)} ");
                 cmd.Append($"where {EscapeWhereList(tableInfo.KeyColumns)};");
 
                 var multi = await connection.QueryMultipleAsync(cmd.ToString(), entityToUpdate, transaction, commandTimeout);

--- a/Dapper.Database/Adapters/SqlAdapter.cs
+++ b/Dapper.Database/Adapters/SqlAdapter.cs
@@ -211,9 +211,9 @@ namespace Dapper.Database.Adapters
                         var wc = string.IsNullOrWhiteSpace(q.Sql) ? $"where {EscapeWhereList(tableInfo.KeyColumns)}" : q.Sql;
 
                         if (string.IsNullOrEmpty(q.FromClause))
-                            return $"select {EscapeColumnList(tableInfo.SelectColumns, tableInfo.TableName)} from { EscapeTableName(tableInfo)} {wc}";
+                            return $"select {EscapeColumnListWithAliases(tableInfo.SelectColumns, tableInfo.TableName)} from { EscapeTableName(tableInfo)} {wc}";
                         else
-                            return $"select {EscapeColumnList(tableInfo.SelectColumns, tableInfo.TableName)} {wc}";
+                            return $"select {EscapeColumnListWithAliases(tableInfo.SelectColumns, tableInfo.TableName)} {wc}";
                     }
                 );
 
@@ -241,9 +241,9 @@ namespace Dapper.Database.Adapters
                 var wc = string.IsNullOrWhiteSpace(q.Sql) ? $"where {EscapeWhereList(tableInfo.KeyColumns)}" : q.Sql;
 
                 if (string.IsNullOrEmpty(q.FromClause))
-                    return $"select {EscapeColumnList(tableInfo.SelectColumns, tableInfo.TableName)} from { EscapeTableName(tableInfo)} {wc}";
+                    return $"select {EscapeColumnListWithAliases(tableInfo.SelectColumns, tableInfo.TableName)} from { EscapeTableName(tableInfo)} {wc}";
                 else
-                    return $"select {EscapeColumnList(tableInfo.SelectColumns, tableInfo.TableName)} {wc}";
+                    return $"select {EscapeColumnListWithAliases(tableInfo.SelectColumns, tableInfo.TableName)} {wc}";
             }
 
             return q.Sql;
@@ -258,9 +258,9 @@ namespace Dapper.Database.Adapters
             //    var wc = string.IsNullOrWhiteSpace(q) ? $"where {EscapeWhereList(tableInfo.KeyColumns)}" : q;
 
             //    if (!rxFrom.IsMatch(q))
-            //        return $"select {EscapeColumnList(tableInfo.SelectColumns, tableInfo.TableName)} from { EscapeTableName(tableInfo)} {wc}";
+            //        return $"select {EscapeColumnListWithAliases(tableInfo.SelectColumns, tableInfo.TableName)} from { EscapeTableName(tableInfo)} {wc}";
             //    else
-            //        return $"select {EscapeColumnList(tableInfo.SelectColumns, tableInfo.TableName)} {wc}";
+            //        return $"select {EscapeColumnListWithAliases(tableInfo.SelectColumns, tableInfo.TableName)} {wc}";
             //}
             //return sql;
 
@@ -317,7 +317,15 @@ namespace Dapper.Database.Adapters
         /// <param name="columns"></param>
         /// <param name="tableName"></param> 
         /// <returns></returns>
-        public virtual string EscapeColumnList(IEnumerable<ColumnInfo> columns, string tableName = null) => string.Join(", ", columns.Select(ci => (tableName != null ? EscapeTableName(tableName) + "." : "") + EscapeColumnn(ci.ColumnName) + (ci.ColumnName != ci.PropertyName ? " AS " + EscapeColumnn(ci.PropertyName) : "")));
+        public virtual string EscapeColumnList(IEnumerable<ColumnInfo> columns, string tableName = null) => string.Join(", ", columns.Select(ci => (tableName != null ? EscapeTableName(tableName) + "." : "") + EscapeColumnn(ci.ColumnName)));
+
+        /// <summary>
+        /// Returns the format for columns
+        /// </summary>
+        /// <param name="columns"></param>
+        /// <param name="tableName"></param> 
+        /// <returns></returns>
+        public virtual string EscapeColumnListWithAliases(IEnumerable<ColumnInfo> columns, string tableName = null) => string.Join(", ", columns.Select(ci => (tableName != null ? EscapeTableName(tableName) + "." : "") + EscapeColumnn(ci.ColumnName) + (ci.ColumnName != ci.PropertyName ? " AS " + EscapeColumnn(ci.PropertyName) : "")));
 
         /// <summary>
         /// Returns the format for where clause

--- a/Dapper.Database/Adapters/SqlCeServerAdapter.cs
+++ b/Dapper.Database/Adapters/SqlCeServerAdapter.cs
@@ -28,7 +28,7 @@ namespace Dapper.Database.Adapters
             if (tableInfo.GeneratedColumns.Any() && tableInfo.KeyColumns.Any())
             {
 
-                var selectcmd = new StringBuilder($"select {EscapeColumnList(tableInfo.GeneratedColumns, tableInfo.TableName)} from {EscapeTableName(tableInfo)} ");
+                var selectcmd = new StringBuilder($"select {EscapeColumnListWithAliases(tableInfo.GeneratedColumns, tableInfo.TableName)} from {EscapeTableName(tableInfo)} ");
 
                 if (tableInfo.KeyColumns.Any(k => k.IsIdentity))
                 {
@@ -85,7 +85,7 @@ namespace Dapper.Database.Adapters
 
             if (tableInfo.GeneratedColumns.Any() && tableInfo.KeyColumns.Any())
             {
-                var selectcmd = new StringBuilder($"select {EscapeColumnList(tableInfo.GeneratedColumns, tableInfo.TableName)} from {EscapeTableName(tableInfo)} ");
+                var selectcmd = new StringBuilder($"select {EscapeColumnListWithAliases(tableInfo.GeneratedColumns, tableInfo.TableName)} from {EscapeTableName(tableInfo)} ");
                 selectcmd.Append($"where {EscapeWhereList(tableInfo.KeyColumns)};");
 
                 connection.Execute(cmd.ToString(), entityToUpdate, transaction, commandTimeout);
@@ -176,7 +176,7 @@ namespace Dapper.Database.Adapters
             if (tableInfo.GeneratedColumns.Any() && tableInfo.KeyColumns.Any())
             {
 
-                var selectcmd = new StringBuilder($"select {EscapeColumnList(tableInfo.GeneratedColumns, tableInfo.TableName)} from {EscapeTableName(tableInfo)} ");
+                var selectcmd = new StringBuilder($"select {EscapeColumnListWithAliases(tableInfo.GeneratedColumns, tableInfo.TableName)} from {EscapeTableName(tableInfo)} ");
 
                 if (tableInfo.KeyColumns.Any(k => k.IsIdentity))
                 {
@@ -233,7 +233,7 @@ namespace Dapper.Database.Adapters
 
             if (tableInfo.GeneratedColumns.Any() && tableInfo.KeyColumns.Any())
             {
-                var selectcmd = new StringBuilder($"select {EscapeColumnList(tableInfo.GeneratedColumns, tableInfo.TableName)} from {EscapeTableName(tableInfo)} ");
+                var selectcmd = new StringBuilder($"select {EscapeColumnListWithAliases(tableInfo.GeneratedColumns, tableInfo.TableName)} from {EscapeTableName(tableInfo)} ");
                 selectcmd.Append($"where {EscapeWhereList(tableInfo.KeyColumns)};");
 
                 await connection.ExecuteAsync(cmd.ToString(), entityToUpdate, transaction, commandTimeout);

--- a/Dapper.Database/Adapters/SqlServerAdapter.cs
+++ b/Dapper.Database/Adapters/SqlServerAdapter.cs
@@ -28,7 +28,7 @@ namespace Dapper.Database.Adapters
 
             if (tableInfo.GeneratedColumns.Any() && tableInfo.KeyColumns.Any())
             {
-                cmd.Append($"; select {EscapeColumnList(tableInfo.GeneratedColumns, tableInfo.TableName)} from {EscapeTableName(tableInfo)} ");
+                cmd.Append($"; select {EscapeColumnListWithAliases(tableInfo.GeneratedColumns, tableInfo.TableName)} from {EscapeTableName(tableInfo)} ");
 
                 if (tableInfo.KeyColumns.Any(k => k.IsIdentity))
                 {
@@ -79,7 +79,7 @@ namespace Dapper.Database.Adapters
 
             if (tableInfo.GeneratedColumns.Any() && tableInfo.KeyColumns.Any())
             {
-                cmd.Append($"; select {EscapeColumnList(tableInfo.GeneratedColumns, tableInfo.TableName)} from {EscapeTableName(tableInfo)} ");
+                cmd.Append($"; select {EscapeColumnListWithAliases(tableInfo.GeneratedColumns, tableInfo.TableName)} from {EscapeTableName(tableInfo)} ");
                 cmd.Append($"where {EscapeWhereList(tableInfo.KeyColumns)};");
 
                 var multi = connection.QueryMultiple(cmd.ToString(), entityToUpdate, transaction, commandTimeout);
@@ -121,7 +121,7 @@ namespace Dapper.Database.Adapters
 
             if (tableInfo.GeneratedColumns.Any() && tableInfo.KeyColumns.Any())
             {
-                cmd.Append($"; select {EscapeColumnList(tableInfo.GeneratedColumns, tableInfo.TableName)} from {EscapeTableName(tableInfo)} ");
+                cmd.Append($"; select {EscapeColumnListWithAliases(tableInfo.GeneratedColumns, tableInfo.TableName)} from {EscapeTableName(tableInfo)} ");
 
                 if (tableInfo.KeyColumns.Any(k => k.IsIdentity))
                 {
@@ -172,7 +172,7 @@ namespace Dapper.Database.Adapters
 
             if (tableInfo.GeneratedColumns.Any() && tableInfo.KeyColumns.Any())
             {
-                cmd.Append($"; select {EscapeColumnList(tableInfo.GeneratedColumns, tableInfo.TableName)} from {EscapeTableName(tableInfo)} ");
+                cmd.Append($"; select {EscapeColumnListWithAliases(tableInfo.GeneratedColumns, tableInfo.TableName)} from {EscapeTableName(tableInfo)} ");
                 cmd.Append($"where {EscapeWhereList(tableInfo.KeyColumns)};");
 
                 var multi = await connection.QueryMultipleAsync(cmd.ToString(), entityToUpdate, transaction, commandTimeout);

--- a/Dapper.Tests.Database/Tests/TestModels.cs
+++ b/Dapper.Tests.Database/Tests/TestModels.cs
@@ -24,6 +24,17 @@ namespace Dapper.Tests.Database
         public string LastName { get; set; }
     }
 
+    [Table("Person")]
+    public class PersonUniqueIdentifierWithAliases
+    {
+        [Key]
+        public Guid GuidId { get; set; }
+        [Column("FirstName")]
+        public string First { get; set; }
+        [Column("LastName")]
+        public string Last { get; set; }
+    }
+
 
     [Table("Person")]
     public class PersonCompositeKey

--- a/Dapper.Tests.Database/Tests/TestSuiteDelete.cs
+++ b/Dapper.Tests.Database/Tests/TestSuiteDelete.cs
@@ -43,6 +43,21 @@ namespace Dapper.Tests.Database
 
         [Fact]
         [Trait("Category", "Delete")]
+        public void DeleteUniqueIdentifierWithAliases()
+        {
+            using (var db = GetSqlDatabase())
+            {
+                var p = new PersonUniqueIdentifierWithAliases { GuidId = Guid.NewGuid(), First = "Alice", Last = "Jones" };
+                Assert.True(db.Insert(p));
+                Assert.True(db.Delete(p));
+
+                var gp = db.Get(p);
+                Assert.Null(gp);
+            }
+        }
+
+        [Fact]
+        [Trait("Category", "Delete")]
         public void DeleteIdentity()
         {
             using (var db = GetSqlDatabase())

--- a/Dapper.Tests.Database/Tests/TestSuiteDeleteAsync.cs
+++ b/Dapper.Tests.Database/Tests/TestSuiteDeleteAsync.cs
@@ -43,6 +43,21 @@ namespace Dapper.Tests.Database
 
         [Fact]
         [Trait("Category", "Delete")]
+        public async Task DeleteUniqueIdentifierWithAliasesAsync()
+        {
+            using (var connection = GetSqlDatabase())
+            {
+                var p = new PersonUniqueIdentifierWithAliases { GuidId = Guid.NewGuid(), First = "Alice", Last = "Jones" };
+                Assert.True(await connection.InsertAsync(p));
+                Assert.True(await connection.DeleteAsync(p));
+
+                var gp = await connection.GetAsync(p);
+                Assert.Null(gp);
+            }
+        }
+
+        [Fact]
+        [Trait("Category", "Delete")]
         public async Task DeleteIdentityAsync()
         {
             using (var connection = GetSqlDatabase())

--- a/Dapper.Tests.Database/Tests/TestSuiteInsert.cs
+++ b/Dapper.Tests.Database/Tests/TestSuiteInsert.cs
@@ -43,6 +43,21 @@ namespace Dapper.Tests.Database
 
         [Fact]
         [Trait("Category", "Insert")]
+        public void InsertUniqueIdentifierWithAliases()
+        {
+            using (var db = GetSqlDatabase())
+            {
+                var p = new PersonUniqueIdentifierWithAliases { GuidId = Guid.NewGuid(), First = "Alice", Last = "Jones" };
+                Assert.True(db.Insert(p));
+                var gp = db.Get<PersonUniqueIdentifierWithAliases>(p.GuidId);
+
+                Assert.Equal(p.First, gp.First);
+                Assert.Equal(p.Last, gp.Last);
+            }
+        }
+
+        [Fact]
+        [Trait("Category", "Insert")]
         public void InsertPersonCompositeKey()
         {
             using (var db = GetSqlDatabase())
@@ -79,7 +94,7 @@ namespace Dapper.Tests.Database
                 Assert.Equal(p.IdentityId, gp.IdentityId);
                 Assert.Null(gp.Notes);
                 Assert.Null(gp.UpdatedOn);
-                Assert.Equal(dnow.ToString("yyyy-MM-dd HH:mm"), gp.CreatedOn.Value.ToString("yyyy-MM-dd HH:mm"));
+                Assert.InRange(gp.CreatedOn.Value, dnow.AddSeconds(-1), dnow.AddSeconds(1)); // to cover fractional seconds rounded up/down (amounts supported between databases vary, but should all be ±1 second at most. )
                 Assert.Equal(p.FirstName, gp.FirstName);
                 Assert.Equal(p.LastName, gp.LastName);
             }

--- a/Dapper.Tests.Database/Tests/TestSuiteInsertAsync.cs
+++ b/Dapper.Tests.Database/Tests/TestSuiteInsertAsync.cs
@@ -43,6 +43,21 @@ namespace Dapper.Tests.Database
         }
 
         [Fact]
+        [Trait("Category", "Insert")]
+        public async Task InsertUniqueIdentifierWithAliasesAsync()
+        {
+            using (var connection = GetSqlDatabase())
+            {
+                var p = new PersonUniqueIdentifierWithAliases { GuidId = Guid.NewGuid(), First = "Alice", Last = "Jones" };
+                Assert.True(await connection.InsertAsync(p));
+                var gp = await connection.GetAsync<PersonUniqueIdentifierWithAliases>(p.GuidId);
+
+                Assert.Equal(p.First, gp.First);
+                Assert.Equal(p.Last, gp.Last);
+            }
+        }
+
+        [Fact]
         [Trait("Category", "InsertAsync")]
         public async Task InsertPersonCompositeKeyAsync()
         {
@@ -80,7 +95,7 @@ namespace Dapper.Tests.Database
                 Assert.Equal(p.IdentityId, gp.IdentityId);
                 Assert.Null(gp.Notes);
                 Assert.Null(gp.UpdatedOn);
-                Assert.Equal(dnow.ToString("yyyy-MM-dd HH:mm"), gp.CreatedOn.Value.ToString("yyyy-MM-dd HH:mm"));
+                Assert.InRange(gp.CreatedOn.Value, dnow.AddSeconds(-1), dnow.AddSeconds(1)); // to cover fractional seconds rounded up/down (amounts supported between databases vary, but should all be ±1 second at most. )
                 Assert.Equal(p.FirstName, gp.FirstName);
                 Assert.Equal(p.LastName, gp.LastName);
             }

--- a/Dapper.Tests.Database/Tests/TestSuiteUpdate.cs
+++ b/Dapper.Tests.Database/Tests/TestSuiteUpdate.cs
@@ -52,6 +52,26 @@ namespace Dapper.Tests.Database
 
         [Fact]
         [Trait("Category", "Update")]
+        public void UpdateUniqueIdentifierWithAliases()
+        {
+            using (var db = GetSqlDatabase())
+            {
+                var p = new PersonUniqueIdentifierWithAliases { GuidId = Guid.NewGuid(), First = "Alice", Last = "Jones" };
+                Assert.True(db.Insert(p));
+
+                p.First = "Greg";
+                p.Last = "Smith";
+                Assert.True(db.Update(p));
+
+                var gp = db.Get<PersonUniqueIdentifierWithAliases>(p.GuidId);
+
+                Assert.Equal(p.First, gp.First);
+                Assert.Equal(p.Last, gp.Last);
+            }
+        }
+
+        [Fact]
+        [Trait("Category", "Update")]
         public void UpdatePersonCompositeKey()
         {
             using (var db = GetSqlDatabase())
@@ -100,8 +120,8 @@ namespace Dapper.Tests.Database
 
                 Assert.Equal(p.IdentityId, gp.IdentityId);
                 Assert.Null(gp.Notes);
-                Assert.Equal(dnow.ToString("yyyy-MM-dd HH:mm"), gp.UpdatedOn.Value.ToString("yyyy-MM-dd HH:mm"));
-                Assert.Equal(dnow.ToString("yyyy-MM-dd HH:mm"), gp.CreatedOn.Value.ToString("yyyy-MM-dd HH:mm"));
+                Assert.InRange(gp.CreatedOn.Value, dnow.AddSeconds(-1), dnow.AddSeconds(1)); // to cover fractional seconds rounded up/down (amounts supported between databases vary, but should all be ±1 second at most. )
+                Assert.InRange(gp.UpdatedOn.Value, dnow.AddMinutes(-1), dnow.AddMinutes(1)); // to cover clock skew, delay in DML, etc.
                 Assert.Equal(p.FirstName, gp.FirstName);
                 Assert.Equal(p.LastName, gp.LastName);
             }

--- a/Dapper.Tests.Database/Tests/TestSuiteUpdateAsync.cs
+++ b/Dapper.Tests.Database/Tests/TestSuiteUpdateAsync.cs
@@ -53,6 +53,26 @@ namespace Dapper.Tests.Database
 
         [Fact]
         [Trait("Category", "UpdateAsync")]
+        public async Task UpdateUniqueIdentifierWithAliasesAsync()
+        {
+            using (var connection = GetSqlDatabase())
+            {
+                var p = new PersonUniqueIdentifierWithAliases { GuidId = Guid.NewGuid(), First = "Alice", Last = "Jones" };
+                Assert.True(await connection.InsertAsync(p));
+
+                p.First = "Greg";
+                p.Last = "Smith";
+                Assert.True(await connection.UpdateAsync(p));
+
+                var gp = await connection.GetAsync<PersonUniqueIdentifierWithAliases>(p.GuidId);
+
+                Assert.Equal(p.First, gp.First);
+                Assert.Equal(p.Last, gp.Last);
+            }
+        }
+
+        [Fact]
+        [Trait("Category", "UpdateAsync")]
         public async Task UpdatePersonCompositeKeyAsync()
         {
             using (var connection = GetSqlDatabase())
@@ -101,8 +121,8 @@ namespace Dapper.Tests.Database
 
                 Assert.Equal(p.IdentityId, gp.IdentityId);
                 Assert.Null(gp.Notes);
-                Assert.Equal(dnow.ToString("yyyy-MM-dd HH:mm"), gp.UpdatedOn.Value.ToString("yyyy-MM-dd HH:mm"));
-                Assert.Equal(dnow.ToString("yyyy-MM-dd HH:mm"), gp.CreatedOn.Value.ToString("yyyy-MM-dd HH:mm"));
+                Assert.InRange(gp.CreatedOn.Value, dnow.AddSeconds(-1), dnow.AddSeconds(1)); // to cover fractional seconds rounded up/down (amounts supported between databases vary, but should all be ±1 second at most. )
+                Assert.InRange(gp.UpdatedOn.Value, dnow.AddMinutes(-1), dnow.AddMinutes(1)); // to cover clock skew, delay in DML, etc.
                 Assert.Equal(p.FirstName, gp.FirstName);
                 Assert.Equal(p.LastName, gp.LastName);
             }

--- a/Dapper.Tests.Database/Tests/TestSuiteUpsertAsync.cs
+++ b/Dapper.Tests.Database/Tests/TestSuiteUpsertAsync.cs
@@ -54,6 +54,26 @@ namespace Dapper.Tests.Database
 
         [Fact]
         [Trait("Category", "UpsertAsync")]
+        public async Task UpsertUniqueIdentifierWithAliasesAsync()
+        {
+            using (var connection = GetSqlDatabase())
+            {
+                var p = new PersonUniqueIdentifierWithAliases { GuidId = Guid.NewGuid(), First = "Alice", Last = "Jones" };
+                Assert.True(await connection.UpsertAsync(p));
+
+                p.First = "Greg";
+                p.Last = "Smith";
+                Assert.True(await connection.UpsertAsync(p));
+
+                var gp = await connection.GetAsync<PersonUniqueIdentifierWithAliases>(p.GuidId);
+
+                Assert.Equal(p.First, gp.First);
+                Assert.Equal(p.Last, gp.Last);
+            }
+        }
+
+        [Fact]
+        [Trait("Category", "UpsertAsync")]
         public async Task UpsertPersonCompositeKeyAsync()
         {
             using (var connection = GetSqlDatabase())
@@ -102,8 +122,8 @@ namespace Dapper.Tests.Database
 
                 Assert.Equal(p.IdentityId, gp.IdentityId);
                 Assert.Null(gp.Notes);
-                Assert.Equal(dnow.ToString("yyyy-MM-dd HH:mm"), gp.UpdatedOn.Value.ToString("yyyy-MM-dd HH:mm"));
-                Assert.Equal(dnow.ToString("yyyy-MM-dd HH:mm"), gp.CreatedOn.Value.ToString("yyyy-MM-dd HH:mm"));
+                Assert.InRange(gp.CreatedOn.Value, dnow.AddSeconds(-1), dnow.AddSeconds(1)); // to cover fractional seconds rounded up/down (amounts supported between databases vary, but should all be ±1 second at most. )
+                Assert.InRange(gp.UpdatedOn.Value, dnow.AddMinutes(-1), dnow.AddMinutes(1)); // to cover clock skew, delay in DML, etc.
                 Assert.Equal(p.FirstName, gp.FirstName);
                 Assert.Equal(p.LastName, gp.LastName);
             }
@@ -153,8 +173,8 @@ namespace Dapper.Tests.Database
                 Assert.Equal(p.IdentityId, gp.IdentityId);
                 Assert.Equal("Alice", gp.FirstName);
                 Assert.Equal("Smith", gp.LastName);
-                Assert.Equal(dnow.ToString("yyyy-MM-dd HH:mm"), gp.CreatedOn.Value.ToString("yyyy-MM-dd HH:mm"));
-                Assert.Equal(dnow.ToString("yyyy-MM-dd HH:mm"), gp.UpdatedOn.Value.ToString("yyyy-MM-dd HH:mm"));
+                Assert.InRange(gp.CreatedOn.Value, dnow.AddSeconds(-1), dnow.AddSeconds(1)); // to cover fractional seconds rounded up/down (amounts supported between databases vary, but should all be ±1 second at most. )
+                Assert.InRange(gp.UpdatedOn.Value, dnow.AddMinutes(-1), dnow.AddMinutes(1)); // to cover clock skew, delay in DML, etc.
             }
         }
 


### PR DESCRIPTION
# Aliases 

`EscapeColumnList` adds aliases (e.g. `Foo AS Bar`) if a column's `ColumnName` and `PropertyName` are different.   However, we found that in practice DML statements (`INSERT/UPDATE/DELETE)` were being generated with aliases, and failing due to invalid SQL.  Only `SELECT` statements support (or even need) aliases.

This is now fixed, and we added a copy of `PersonUniqueIdentifier` that uses different property names to test this case.

# Time
The unit tests that were checking that `CreatedOn` and `UpdatedOn` actually failed for us a couple of times because the clock changed minutes right as several of the relevant tests were running.  Replacing with something hopefully more robust:

* `CreatedOn` - because this is sent from the server, we can trust the stored value will be the same, but rounded to the precision of the underlying data column (up OR down).  However, virtually all databases should support a precision of 1 second, so this should work for all current and any future implementations.
* `UpdatedOn` - this one is trickier because it is entirely possible the database is running on a different server or otherwise has a skewed clock.  However, since it realistically won't be more than a minute, this should be sufficient and avoid the hard cutoff of a minute.

# Additional notes

I verified this on the following databases:

* MySQL (net452 / netcoreapp1.0 / netcoreapp2.0)
* PostgreSQL (net452 / netcoreapp1.0 / netcoreapp2.0)
* SQLite (netcoreapp1.0 / netcoreapp2.0)
* Oracle (net452 / netcoreapp2.0) - **separate branch in progress**



