### PR TITLE
Simplified the naming of the private Delete Query Builder helper methods

### DIFF
--- a/Dapper.Database/Extensions/SqlDeleteExtensionHelpers.cs
+++ b/Dapper.Database/Extensions/SqlDeleteExtensionHelpers.cs
@@ -1,0 +1,83 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Data;
+
+namespace Dapper.Database.Extensions
+{
+    public static partial class SqlMapperExtensions
+    {
+        private struct GeneratedQuery
+        {
+            public GeneratedQuery(DynamicParameters parameters, string sqlStatement) : this()
+            {
+                Parameters = parameters;
+                SqlStatement = sqlStatement;
+            }
+
+            public DynamicParameters Parameters { get; }
+            public string SqlStatement { get; }
+        }
+
+        /// <summary>
+        /// Builds a Delete query, formatted for the adapter specified for the type (MsSql, Oracle, Etc.).
+        /// </summary>
+        /// <typeparam name="T">The entity type to generate the query with</typeparam>
+        /// <param name="connection">The connection used to target the language the SQL statement will be generated from</param>
+        /// <param name="entityToDelete">The (T) entity, with some form of <see cref="KeyAttribute"/> specified to bound the query with.
+        /// The values on the entity passed in will be used as the values in the <see cref="DynamicParameters"/> returned from the <see cref="GeneratedQuery"/>.</param>
+        /// <returns>A <see cref="GeneratedQuery"/> containing the RawSql text and the <see cref="DynamicParameters"/> to bound the query with.</returns>
+        private static GeneratedQuery GenerateDeleteQuery<T>(IDbConnection connection, T entityToDelete) where T : class
+        {
+            var type = typeof(T);
+            var adapter = GetFormatter(connection);
+            var tinfo = TableInfoCache(type);
+            var keys = tinfo.GetCompositeKeys("Delete");
+            var dynParms = new DynamicParameters();
+            foreach (var key in keys)
+            {
+                var value = key.GetValue(entityToDelete);
+                dynParms.Add(key.ColumnName, value);
+            }
+
+            var qWhere = $" where {adapter.EscapeWhereList(tinfo.KeyColumns)}";
+            return new GeneratedQuery(dynParms, adapter.DeleteQuery(tinfo, qWhere));
+        }
+
+        /// <summary>
+        /// Builds a Delete query, formatted for the adapter specified for the type (MsSql, Oracle, Etc.).
+        /// </summary>
+        /// <typeparam name="T">The entity type to generate the query with</typeparam>
+        /// <param name="connection">The connection used to target the language the SQL statement will be generated from</param>
+        /// <param name="primaryKeyValue">The primary key value for the (T) type. This will be used to bound the query.</param>
+        /// <returns>A <see cref="GeneratedQuery"/> containing the RawSql text and the <see cref="DynamicParameters"/> to bound the query with.</returns>
+        private static GeneratedQuery GenerateDeleteQuery<T>(IDbConnection connection, object primaryKeyValue) where T : class
+        {
+            var type = typeof(T);
+            var adapter = GetFormatter(connection);
+            var tinfo = TableInfoCache(type);
+
+            var key = tinfo.GetSingleKey("Delete");
+            var dynParms = new DynamicParameters();
+            dynParms.Add(key.PropertyName, primaryKeyValue);
+            var qWhere = $" where {adapter.EscapeWhereList(tinfo.KeyColumns)}";
+
+            return new GeneratedQuery(dynParms, adapter.DeleteQuery(tinfo, qWhere));
+        }
+
+        /// <summary>
+        /// Builds a Delete query, formatted for the adapter specified for the type (MsSql, Oracle, Etc.).
+        /// NOTE: If a null is passed in to the whereClause, the generated delete statement will be unbounded (basically a DeleteAll statement)
+        /// </summary>
+        /// <typeparam name="T">The entity type to generate the query with</typeparam>
+        /// <param name="connection">The connection used to target the language the SQL statement will be generated from</param>
+        /// <param name="whereClause">The static where clause to attach to the end of a Delete statement</param>
+        /// <returns>The static Delete statement</returns>
+        private static string GenerateDeleteQuery<T>(IDbConnection connection, string whereClause)
+        {
+            var type = typeof(T);
+            var adapter = GetFormatter(connection);
+            var tinfo = TableInfoCache(type);
+
+            return adapter.DeleteQuery(tinfo, whereClause);
+        }
+    }
+}

--- a/Dapper.Database/Extensions/SqlDeleteExtensions.Async.cs
+++ b/Dapper.Database/Extensions/SqlDeleteExtensions.Async.cs
@@ -9,7 +9,6 @@ namespace Dapper.Database.Extensions
     /// </summary>
     public static partial class SqlMapperExtensions
     {
-
         #region DeleteAsync Extensions
         /// <summary>
         /// Delete entity in table "Ts" that match the key values of the entity (T) passed in
@@ -27,9 +26,9 @@ namespace Dapper.Database.Extensions
                 throw new ArgumentNullException(nameof(entityToDelete), "Cannot Delete null Object");
             }
 
-            var queryWithParameters = BuildDeleteByEntityQueryWithParams(connection, entityToDelete);
+            var deleteQuery = GenerateDeleteQuery(connection, entityToDelete);
 
-            return await connection.ExecuteAsync(queryWithParameters.SqlQuery, queryWithParameters.DynamicParameters, transaction, commandTimeout) > 0;
+            return await connection.ExecuteAsync(deleteQuery.SqlStatement, deleteQuery.Parameters, transaction, commandTimeout) > 0;
         }
 
         /// <summary>
@@ -42,9 +41,9 @@ namespace Dapper.Database.Extensions
         /// <returns>true if deleted, false if not found</returns>
         public static async Task<bool> DeleteAsync<T>(this IDbConnection connection, object primaryKeyValue, IDbTransaction transaction = null, int? commandTimeout = null) where T : class
         {
-            var queryWithParameters = BuildDeleteByPkQueryWithParams<T>(connection, primaryKeyValue);
+            var deleteQuery = GenerateDeleteQuery<T>(connection, primaryKeyValue);
 
-            return await connection.ExecuteAsync(queryWithParameters.SqlQuery, queryWithParameters.DynamicParameters, transaction, commandTimeout) > 0;
+            return await connection.ExecuteAsync(deleteQuery.SqlStatement, deleteQuery.Parameters, transaction, commandTimeout) > 0;
         }
 
         /// <summary>
@@ -63,7 +62,7 @@ namespace Dapper.Database.Extensions
                 throw new ArgumentNullException(nameof(whereClause));
             }
 
-            return await connection.ExecuteAsync(BuildBasicDeleteQueryFromSql<T>(connection, whereClause), null, transaction, commandTimeout) > 0;
+            return await connection.ExecuteAsync(GenerateDeleteQuery<T>(connection, whereClause), null, transaction, commandTimeout) > 0;
         }
 
         /// <summary>
@@ -83,7 +82,7 @@ namespace Dapper.Database.Extensions
                 throw new ArgumentNullException(nameof(whereClause));
             }
 
-            return await connection.ExecuteAsync(BuildBasicDeleteQueryFromSql<T>(connection, whereClause), parameters, transaction, commandTimeout) > 0;
+            return await connection.ExecuteAsync(GenerateDeleteQuery<T>(connection, whereClause), parameters, transaction, commandTimeout) > 0;
         }
 
         /// <summary>
@@ -95,9 +94,8 @@ namespace Dapper.Database.Extensions
         /// <returns>true if deleted, false if not found</returns>
         public static async Task<bool> DeleteAllAsync<T>(this IDbConnection connection, IDbTransaction transaction = null, int? commandTimeout = null) where T : class
         {
-            return await connection.ExecuteAsync(BuildBasicDeleteQueryFromSql<T>(connection, null), null, transaction, commandTimeout) > 0;
+            return await connection.ExecuteAsync(GenerateDeleteQuery<T>(connection, (string) null), null, transaction, commandTimeout) > 0;
         }
-
         #endregion
     }
 }


### PR DESCRIPTION
* Now: GenerateDeleteQuery() with overloads.
* Added documentation
* Moved to a SqlDeleteExtensionHelpers.cs file for clenliness