### PR TITLE
ODP.NET Core official release version.

### DIFF
--- a/Dapper.Tests.Database/Dapper.Tests.Database.csproj
+++ b/Dapper.Tests.Database/Dapper.Tests.Database.csproj
@@ -53,7 +53,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
     <PackageReference Include="Microsoft.Data.Sqlite" Version="2.0.0" />
-    <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.12.0-beta3" />
+    <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.18.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
They went with "2.18.3" instead of the expected "2.12.0", but otherwise it's what we expected.

I have confirmed that the new version passes tests against 11.2.0.2 XE and 12.2.0.1 Enterprise Edition.